### PR TITLE
Feature/add visualization tutorial

### DIFF
--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -65,26 +65,34 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
     def runVisualizationTutorialPart3(self):
         # 1 shot:
         self.mainWindow.moduleSelector().selectModule("Welcome")
-        self.layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
+        self.layoutManager.setLayout(
+            slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView
+        )
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #1: In the Welcome screen.")
 
         # 2 shot:
-        TESTING_DATA_URL = "https://github.com/Slicer/SlicerTestingData/releases/download/"
+        TESTING_DATA_URL = (
+            "https://github.com/Slicer/SlicerTestingData/releases/download/"
+        )
 
         try:
             SampleData.downloadFromURL(
-                fileNames='slicer4minute.mrb',
+                fileNames="slicer4minute.mrb",
                 loadFiles=True,
-                uris=TESTING_DATA_URL + 'SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8',
-                checksums='SHA256:5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8')
-            self.delayDisplay('Finished with download and loading')
+                uris=TESTING_DATA_URL
+                + "SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8",
+                checksums="SHA256:5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8",
+            )
+            self.delayDisplay("Finished with download and loading")
         except:
             pass
 
-        self.mainWindow.moduleSelector().selectModule('Models')
+        self.mainWindow.moduleSelector().selectModule("Models")
         self.Tutorial.nextScreenshot()
-        self.delayDisplay('Screenshot #2: In the Models screen with the sample data loaded.')
+        self.delayDisplay(
+            "Screenshot #2: In the Models screen with the sample data loaded."
+        )
 
         # 3 shot:
         self.pin_buttons = {
@@ -109,7 +117,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.red_slice_node.SetSliceOffset(red_slice_position)
 
         self.Tutorial.nextScreenshot()
-        self.delayDisplay("Screenshot #3: Red slice plane adjusted to position -32 and its visibility toggled on.")
+        self.delayDisplay(
+            "Screenshot #3: Red slice plane adjusted to position -32 and its visibility toggled on."
+        )
 
         # 4 shot:
         skin = slicer.util.getNode(pattern="Skin")
@@ -144,14 +154,20 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         )
 
         # 7 shot:
-        hemispheric_white_matter_display_node = slicer.util.getNode(pattern="hemispheric_white_matter").GetDisplayNode()
+        hemispheric_white_matter_display_node = slicer.util.getNode(
+            pattern="hemispheric_white_matter"
+        ).GetDisplayNode()
 
         hemispheric_white_matter_display_node.SetClipping(True)
 
-        red_plane = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/RedSliceClippingCheckBox")
+        red_plane = self.util.getNamedWidget(
+            "PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/RedSliceClippingCheckBox"
+        )
         red_plane.click()
 
-        green_plane = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/GreenSliceClippingCheckBox")
+        green_plane = self.util.getNamedWidget(
+            "PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/GreenSliceClippingCheckBox"
+        )
         green_plane.click()
 
         self.Tutorial.nextScreenshot()
@@ -177,4 +193,3 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.delayDisplay(
             "Screenshot #9: Final visualization with adjusted camera elevation (40°) and zoom level (0.8x)."
         )
-

--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -149,7 +149,77 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
 
 
     def runVisualizationTutorialPart2(self):
-        pass
+        # 1 shot:
+        volumeNode = slicer.util.getNode("6: CT_Thorax_Abdomen")
+
+        volRenLogic = slicer.modules.volumerendering.logic()
+
+        displayNode = volRenLogic.CreateDefaultVolumeRenderingNodes(volumeNode)
+
+        volumePropertyNode = displayNode.GetVolumePropertyNode()
+
+        preset = volRenLogic.GetPresetByName("CT-Cardiac3")
+
+        volumePropertyNode.Copy(preset)
+
+        displayNode.SetVisibility(1)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #1: Volume rendering enabled with 'CT-Cardiac3'.")
+
+        # 2 shot:
+        layoutManager = slicer.app.layoutManager()
+        threeDWidget = layoutManager.threeDWidget(0)
+        threeDView = threeDWidget.threeDView()
+        threeDView.resetFocalPoint()
+
+        volRenWidget = slicer.modules.volumerendering.widgetRepresentation()
+
+        volumePropertyNodeWidget = slicer.util.findChild(volRenWidget, "VolumePropertyNodeWidget")
+        volumePropertyNodeWidget.setMRMLVolumePropertyNode(volumePropertyNode)
+        volumePropertyNodeWidget.moveAllPoints(250, 0, False)
+
+        cam = slicer.util.getNode(pattern="vtkMRMLCameraNode1")
+        cam.GetCamera().Elevation(-30)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #2:  Change shift value.")
+
+        # 3 shot:
+        roi_button = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/qSlicerVolumeRenderingModuleWidget/DisplayCollapsibleButton/ROICropDisplayCheckBox")
+
+        roi_button.click()
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #3: ROI cropping enabled.")
+
+        # 4 shot:
+        displayNode.SetVisibility(0)
+
+        roiNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLMarkupsROINode")
+
+        roiNode.SetXYZ(-66, 144, -225)
+
+        roiNode.SetRadiusXYZ(30, 50, 60)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #4: ROI position and size adjusted (first configuration).")
+
+        # 5 shot:
+        displayNode.SetVisibility(1)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #5: Displaying ROI.")
+
+        # 6 shot:
+        roiNode.SetXYZ(0, 144, -225)
+
+        roiNode.SetRadiusXYZ(100, 50, 60)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #6: ROI position and size adjusted (second configuration).")
+
+        slicer.mrmlScene.Clear(0)
 
     def runVisualizationTutorialPart3(self):
         # 1 shot:

--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -29,7 +29,10 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
     def test_VisualizationTutorial1(self):
         """Tests parts of the VisualizationTutorial tutorial."""
         self.Tutorial = utils.Tutorial(
-            "Slicer	Welcome", "Sonia Pujol, Ph.D.", "28/08/2024", "description"
+            "Slicer	Visualization Tutorial",
+            "Sonia Pujol, Ph.D.",
+            "24/11/2024",
+            "description",
         )
 
         self.util = utils.util()

--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -9,6 +9,7 @@ from slicer.ScriptedLoadableModule import *
 
 # VisualizationTutorial
 
+
 class VisualizationTutorialTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
@@ -72,10 +73,13 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #2: Loaded the sample dataset.")
 
-
         # 3 shot:
-        scroll_area = self.util.getNamedWidget("CentralWidget/CentralWidgetLayoutFrame/QWidget:0/SlicerDICOMBrowser/ctkDICOMBrowser/dicomTableManager/tableSplitter/patientsTable/tblDicomDatabaseView").getChildren()
-        load_button = self.util.getNamedWidget("CentralWidget/CentralWidgetLayoutFrame/QWidget:0/SlicerDICOMBrowser/ActionButtonsFrame/QPushButton:2")
+        scroll_area = self.util.getNamedWidget(
+            "CentralWidget/CentralWidgetLayoutFrame/QWidget:0/SlicerDICOMBrowser/ctkDICOMBrowser/dicomTableManager/tableSplitter/patientsTable/tblDicomDatabaseView"
+        ).getChildren()
+        load_button = self.util.getNamedWidget(
+            "CentralWidget/CentralWidgetLayoutFrame/QWidget:0/SlicerDICOMBrowser/ActionButtonsFrame/QPushButton:2"
+        )
 
         scroll_area[4].click()
         load_button.click()
@@ -86,7 +90,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         # 4 shot:
         self.mainWindow.moduleSelector().selectModule("Volumes")
 
-        ct_button = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/qSlicerVolumesModuleWidget/DisplayCollapsibleButton/VolumeDisplayWidget/qSlicerScalarVolumeDisplayWidget/PresetsGroupBox/CT_ABDOMEN")
+        ct_button = self.util.getNamedWidget(
+            "PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/qSlicerVolumesModuleWidget/DisplayCollapsibleButton/VolumeDisplayWidget/qSlicerScalarVolumeDisplayWidget/PresetsGroupBox/CT_ABDOMEN"
+        )
         ct_button.click()
 
         self.Tutorial.nextScreenshot()
@@ -100,7 +106,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
             for color in self.COLORS
         }
 
-        link_button = self.util.getNamedWidget("CentralWidget/CentralWidgetLayoutFrame/QSplitter:0/QWidget:0/qMRMLSliceWidgetRed/SliceController/qMRMLSliceControllerWidget/SliceFrame/SliceLinkButton")
+        link_button = self.util.getNamedWidget(
+            "CentralWidget/CentralWidgetLayoutFrame/QSplitter:0/QWidget:0/qMRMLSliceWidgetRed/SliceController/qMRMLSliceControllerWidget/SliceFrame/SliceLinkButton"
+        )
 
         visibility_buttons = {
             color: self.util.getNamedWidget(
@@ -117,7 +125,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Screenshot #5: Linked and activated red slice plane.")
 
         # 6 shot:
-        self.layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalWidescreenView)
+        self.layoutManager.setLayout(
+            slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalWidescreenView
+        )
 
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #6: Set widescreen layout.")
@@ -125,21 +135,23 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         # 7 shot:
         cam = slicer.util.getNode(pattern="vtkMRMLCameraNode1")
         cam.GetCamera().Zoom(0.4)
-    
+
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #7: Zoomed in on the region of interest.")
 
         # 8 shot:
         cam.GetCamera().Azimuth(60)
         cam.GetCamera().Elevation(30)
-    
+
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #8: Rotated view (60° azimuth, 30° elevation).")
 
         # 9 shot:
-        center_button = self.util.getNamedWidget("CentralWidget/CentralWidgetLayoutFrame/QSplitter:0/ThreeDWidget1/qMRMLThreeDViewControllerWidget:0/qMRMLThreeDViewControllerWidget/CenterButton")
+        center_button = self.util.getNamedWidget(
+            "CentralWidget/CentralWidgetLayoutFrame/QSplitter:0/ThreeDWidget1/qMRMLThreeDViewControllerWidget:0/qMRMLThreeDViewControllerWidget/CenterButton"
+        )
         center_button.click()
-    
+
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #9: Centered the 3D view.")
 
@@ -148,7 +160,6 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
 
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #10: Switched to 'Volume Rendering' module.")
-
 
     def runVisualizationTutorialPart2(self):
         # 1 shot:
@@ -177,7 +188,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
 
         volRenWidget = slicer.modules.volumerendering.widgetRepresentation()
 
-        volumePropertyNodeWidget = slicer.util.findChild(volRenWidget, "VolumePropertyNodeWidget")
+        volumePropertyNodeWidget = slicer.util.findChild(
+            volRenWidget, "VolumePropertyNodeWidget"
+        )
         volumePropertyNodeWidget.setMRMLVolumePropertyNode(volumePropertyNode)
         volumePropertyNodeWidget.moveAllPoints(250, 0, False)
 
@@ -188,7 +201,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Screenshot #2:  Change shift value.")
 
         # 3 shot:
-        roi_button = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/qSlicerVolumeRenderingModuleWidget/DisplayCollapsibleButton/ROICropDisplayCheckBox")
+        roi_button = self.util.getNamedWidget(
+            "PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/qSlicerVolumeRenderingModuleWidget/DisplayCollapsibleButton/ROICropDisplayCheckBox"
+        )
 
         roi_button.click()
 
@@ -205,7 +220,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         roiNode.SetRadiusXYZ(30, 50, 60)
 
         self.Tutorial.nextScreenshot()
-        self.delayDisplay("Screenshot #4: ROI position and size adjusted (first configuration).")
+        self.delayDisplay(
+            "Screenshot #4: ROI position and size adjusted (first configuration)."
+        )
 
         # 5 shot:
         displayNode.SetVisibility(1)
@@ -219,7 +236,9 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         roiNode.SetRadiusXYZ(100, 50, 60)
 
         self.Tutorial.nextScreenshot()
-        self.delayDisplay("Screenshot #6: ROI position and size adjusted (second configuration).")
+        self.delayDisplay(
+            "Screenshot #6: ROI position and size adjusted (second configuration)."
+        )
 
         slicer.mrmlScene.Clear(0)
 
@@ -354,15 +373,19 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
         self.delayDisplay(
             "Screenshot #9: Final visualization with adjusted camera elevation (40°) and zoom level (0.8x)."
         )
-    
+
     def downloadAndLoadZip(self):
-        zip_url = "https://www.dropbox.com/s/03emcqnlec4t2s5/3DVisualizationDataset.zip?dl=1"
+        zip_url = (
+            "https://www.dropbox.com/s/03emcqnlec4t2s5/3DVisualizationDataset.zip?dl=1"
+        )
         extraction_subfolder = "3DVisualizationDataset/dataset1_Thorax_Abdomen"
         zip_path = f"{slicer.app.temporaryPath}/3DVisualizationDataset.zip"
 
         urllib.request.urlretrieve(zip_url, zip_path)
-        
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(slicer.app.temporaryPath)
 
-        slicer.dicomDatabase.openDatabase(f"{slicer.app.temporaryPath}/{extraction_subfolder}")
+        slicer.dicomDatabase.openDatabase(
+            f"{slicer.app.temporaryPath}/{extraction_subfolder}"
+        )

--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -1,8 +1,7 @@
-# https://github.com/spujol/SlicerVisualizationTutorial/blob/master/SlicerVisualizationTutorial_SoniaPujol.pdf
-import os
 import slicer
 import zipfile
 import SampleData
+import urllib.request
 
 import Lib.utils as utils
 
@@ -68,8 +67,11 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
 
         # 2 shot:
         self.downloadAndLoadZip()
+        self.mainWindow.moduleSelector().selectModule("DICOM")
+
         self.Tutorial.nextScreenshot()
         self.delayDisplay("Screenshot #2: Loaded the sample dataset.")
+
 
         # 3 shot:
         scroll_area = self.util.getNamedWidget("CentralWidget/CentralWidgetLayoutFrame/QWidget:0/SlicerDICOMBrowser/ctkDICOMBrowser/dicomTableManager/tableSplitter/patientsTable/tblDicomDatabaseView").getChildren()
@@ -355,24 +357,12 @@ class VisualizationTutorialTest(ScriptedLoadableModuleTest):
     
     def downloadAndLoadZip(self):
         zip_url = "https://www.dropbox.com/s/03emcqnlec4t2s5/3DVisualizationDataset.zip?dl=1"
-        zip_file_name = "3DVisualizationDataset.zip"
         extraction_subfolder = "3DVisualizationDataset/dataset1_Thorax_Abdomen"
-        
-        zip_file_path = os.path.join(slicer.app.temporaryPath, zip_file_name)
-        
-        try:
-            if not os.path.exists(zip_file_path):
-                slicer.util.downloadFile(zip_url, zip_file_path)
+        zip_path = f"{slicer.app.temporaryPath}/3DVisualizationDataset.zip"
 
-            extract_dir = slicer.app.temporaryPath
-            with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
-                zip_ref.extractall(extract_dir)
-            
-            dataset_path = os.path.join(extract_dir, extraction_subfolder)
-            
-            for file_name in os.listdir(dataset_path):
-                file_path = os.path.join(dataset_path, file_name)
-                slicer.util.loadNodeFromFile(file_path, properties={})
-            
-        except Exception as e:
-            slicer.util.errorDisplay(f"Error during download or loading: {str(e)}")
+        urllib.request.urlretrieve(zip_url, zip_path)
+        
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(slicer.app.temporaryPath)
+
+        slicer.dicomDatabase.openDatabase(f"{slicer.app.temporaryPath}/{extraction_subfolder}")

--- a/TutorialMaker/Testing/visualization_tutorial.py
+++ b/TutorialMaker/Testing/visualization_tutorial.py
@@ -1,0 +1,180 @@
+# https://github.com/spujol/SlicerVisualizationTutorial/blob/master/SlicerVisualizationTutorial_SoniaPujol.pdf
+import slicer
+import SampleData
+
+import Lib.utils as utils
+
+from slicer.ScriptedLoadableModule import *
+
+# VisualizationTutorial
+
+
+class VisualizationTutorialTest(ScriptedLoadableModuleTest):
+    """
+    This is the test case for your scripted module.
+    Uses ScriptedLoadableModuleTest base class, available at:
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
+    """
+
+    def setUp(self):
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
+        slicer.mrmlScene.Clear(0)
+
+    def runTest(self):
+        """Run as few or as many tests as needed here."""
+        self.setUp()
+        self.test_VisualizationTutorial1()
+
+    def test_VisualizationTutorial1(self):
+        """Tests parts of the VisualizationTutorial tutorial."""
+        self.Tutorial = utils.Tutorial(
+            "Slicer	Welcome", "Sonia Pujol, Ph.D.", "28/08/2024", "description"
+        )
+
+        self.util = utils.util()
+        self.layoutManager = slicer.app.layoutManager()
+        self.mainWindow = slicer.util.mainWindow()
+
+        self.COLORS = ["Red", "Green", "Yellow"]
+        self.CENTRAL_WIDGETS_PATH = "CentralWidget/CentralWidgetLayoutFrame/QSplitter:0/QWidget:0/qMRMLSliceWidget"
+
+        # Clear Output folder
+        self.Tutorial.clearTutorial()
+        self.Tutorial.beginTutorial()
+        self.delayDisplay("Starting the test")
+
+        # Run Visualization Tutorial - Part 1
+        self.runVisualizationTutorialPart1()
+
+        # Run Visualization Tutorial - Part 2
+        self.runVisualizationTutorialPart2()
+
+        # Run Visualization Tutorial - Part 3
+        self.runVisualizationTutorialPart3()
+
+        # Done
+        self.Tutorial.endTutorial()
+        self.delayDisplay("Test passed!")
+
+    def runVisualizationTutorialPart1(self):
+        pass
+
+    def runVisualizationTutorialPart2(self):
+        pass
+
+    def runVisualizationTutorialPart3(self):
+        # 1 shot:
+        self.mainWindow.moduleSelector().selectModule("Welcome")
+        self.layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #1: In the Welcome screen.")
+
+        # 2 shot:
+        TESTING_DATA_URL = "https://github.com/Slicer/SlicerTestingData/releases/download/"
+
+        try:
+            SampleData.downloadFromURL(
+                fileNames='slicer4minute.mrb',
+                loadFiles=True,
+                uris=TESTING_DATA_URL + 'SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8',
+                checksums='SHA256:5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8')
+            self.delayDisplay('Finished with download and loading')
+        except:
+            pass
+
+        self.mainWindow.moduleSelector().selectModule('Models')
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay('Screenshot #2: In the Models screen with the sample data loaded.')
+
+        # 3 shot:
+        self.pin_buttons = {
+            color: self.util.getNamedWidget(
+                f"{self.CENTRAL_WIDGETS_PATH}{color}/SliceController/BarWidget/PinButton"
+            )
+            for color in self.COLORS
+        }
+
+        self.visibility_buttons = {
+            color: self.util.getNamedWidget(
+                f"{self.CENTRAL_WIDGETS_PATH}{color}/SliceController/qMRMLSliceControllerWidget/SliceFrame/SliceVisibilityButton"
+            )
+            for color in self.COLORS
+        }
+
+        red_slice_position = -32
+        self.red_slice_node = slicer.util.getNode("vtkMRMLSliceNodeRed")
+
+        self.pin_buttons["Red"].click()
+        self.visibility_buttons["Red"].click()
+        self.red_slice_node.SetSliceOffset(red_slice_position)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay("Screenshot #3: Red slice plane adjusted to position -32 and its visibility toggled on.")
+
+        # 4 shot:
+        skin = slicer.util.getNode(pattern="Skin")
+        skin.GetDisplayNode().SetOpacity(0.5)
+
+        cam = slicer.util.getNode(pattern="vtkMRMLCameraNode1")
+        cam.GetCamera().Azimuth(45)
+        cam.GetCamera().Elevation(30)
+        cam.GetCamera().Zoom(1.4)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #4: Adjusted the opacity of the skin model to 50% and updated the camera view (45° azimuth, 30° elevation, 1.4x zoom)."
+        )
+
+        # 5 shot:
+        skull_bone = slicer.util.getNode(pattern="skull_bone")
+        skull_bone.GetDisplayNode().SetVisibility(False)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #5: Skull bone model visibility turned off to isolate other structures."
+        )
+
+        # 6 shot:
+        self.pin_buttons["Green"].click()
+        self.visibility_buttons["Green"].click()
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #6: Green slice plane visibility toggled on and its position adjusted."
+        )
+
+        # 7 shot:
+        hemispheric_white_matter_display_node = slicer.util.getNode(pattern="hemispheric_white_matter").GetDisplayNode()
+
+        hemispheric_white_matter_display_node.SetClipping(True)
+
+        red_plane = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/RedSliceClippingCheckBox")
+        red_plane.click()
+
+        green_plane = self.util.getNamedWidget("PanelDockWidget/dockWidgetContents/ModulePanel/ScrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/ModelsModuleWidget/ClippingButton/MRMLClipNodeWidget/GreenSliceClippingCheckBox")
+        green_plane.click()
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #7: Enabled clipping for the hemispheric white matter model using red and green slice planes."
+        )
+
+        # 8 shot:
+        green_slice_position = -32
+        self.green_slice_node = slicer.util.getNode("vtkMRMLSliceNodeGreen")
+        self.green_slice_node.SetSliceOffset(green_slice_position)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #8: Adjusted the position of the green slice plane to -32 for further analysis."
+        )
+
+        # 9 shot:
+        cam.GetCamera().Elevation(40)
+        cam.GetCamera().Zoom(0.8)
+
+        self.Tutorial.nextScreenshot()
+        self.delayDisplay(
+            "Screenshot #9: Final visualization with adjusted camera elevation (40°) and zoom level (0.8x)."
+        )
+


### PR DESCRIPTION
This PR aims to add the [visualization_tutorial.py](https://github.com/pauloguilhermepp/TutorialMaker/blob/feature/add_visualization_tutorial/TutorialMaker/Testing/visualization_tutorial.py) based on the [Visualization Tutorial](https://github.com/spujol/SlicerVisualizationTutorial/blob/master/SlicerVisualizationTutorial_SoniaPujol.pdf), as was previously done for the [Slicer4 Minute](https://www.dropbox.com/scl/fi/2jqxtrkfyniowrua54xg1/Slicer4.10minute_SoniaPujol.pdf?rlkey=8r28e7t5mzzazkxknqrkez2zj&e=1&dl=0%7C) tutorial in [fourMin_tutorial.py](https://github.com/pauloguilhermepp/TutorialMaker/blob/f2684a4f6a6b502e6356f0d7e394e70698ad0dd0/TutorialMaker/Testing/fourMin_tutorial.py).