### PR TITLE
Streamline execution of tests downloading Slicer 

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "**.py"
 
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,6 +36,12 @@ jobs:
           qt5dxcb-plugin \
           libsm6
 
+    - name: Install XVFB prerequisites
+      run: |
+        sudo apt-get install \
+          xvfb \
+          x11-xserver-utils
+
     - name: Download Slicer
       id: slicer-download
       run: |
@@ -68,17 +74,39 @@ jobs:
         echo "slicer-executable=${SLICER_EXECUTABLE}" >> $GITHUB_OUTPUT
 
     - name: Check Slicer installation
-      uses: coactions/setup-xvfb@v1.0.1
-      with:
-        run:
+      run: |
+        function cleanup() {
+          echo "Cleaning up..."
+          local xvfb_pids=`ps aux | grep tmp/xvfb-run | grep -v grep | awk '{print $2}'`
+          if [ "$xvfb_pids" != "" ]; then
+              echo "Killing the following xvfb processes: $xvfb_pids"
+              sudo kill $xvfb_pids
+          else
+              echo "No xvfb processes to kill"
+          fi
+        }
+        trap cleanup EXIT
+
+        xvfb-run --auto-servernum \
           ${SLICER_EXECUTABLE} --version
       env:
         SLICER_EXECUTABLE: ${{ steps.slicer-download.outputs.slicer-executable }}
 
     - name: Test SlicerTutorialMaker
-      uses: coactions/setup-xvfb@v1.0.1
-      with:
-        run: |
+      run: |
+        function cleanup() {
+          echo "Cleaning up..."
+          local xvfb_pids=`ps aux | grep tmp/xvfb-run | grep -v grep | awk '{print $2}'`
+          if [ "$xvfb_pids" != "" ]; then
+              echo "Killing the following xvfb processes: $xvfb_pids"
+              sudo kill $xvfb_pids
+          else
+              echo "No xvfb processes to kill"
+          fi
+        }
+        trap cleanup EXIT
+
+        xvfb-run --auto-servernum \
           ${SLICER_EXECUTABLE} \
             --no-splash \
             --testing \

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,9 +19,6 @@ jobs:
   build-test:
     runs-on: ubuntu-22.04
 
-    env:
-      BUILD_TYPE: Release
-
     steps:
 
     - name: Checkout out SlicerTutorialMaker
@@ -29,89 +26,66 @@ jobs:
       with:
         path: ${{ github.workspace }}/SlicerTutorialMaker
 
-    - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.24.2
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '5.15.2'
-        host: 'linux'
-        dir: '/opt/qt'
-        modules: 'qtwebengine'
-        setup-python: false
-
-    - name: Checkout out Slicer
-      uses: actions/checkout@v3
-      with:
-        repository: Slicer/Slicer
-        path: ${{ github.workspace }}/Slicer
-
-    - id: slicer-build
-      name: Build Slicer
+    - name: Install Slicer prerequisites
       run: |
-        Qt5_DIR=$QT_ROOT_DIR/lib/cmake/Qt5
+        sudo apt-get install \
+          libglu1-mesa \
+          libpulse-mainloop-glib0 \
+          libnss3 \
+          libasound2 \
+          qt5dxcb-plugin \
+          libsm6
 
-        Slicer_SOURCE_DIR=${{ github.workspace }}/Slicer
-        Slicer_BUILD_DIR=${{ github.workspace }}/Slicer-build
-
-        cmake \
-          -GNinja \
-          -DBUILD_TESTING:BOOL=OFF \
-          -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE \
-          -DQt5_DIR:PATH=$Qt5_DIR \
-          -DSlicer_BUILD_APPLICATIONUPDATE_SUPPORT:BOOL=OFF \
-          -DSlicer_BUILD_DOCUMENTATION:BOOL=OFF \
-          -DSlicer_BUILD_BRAINSTOOLS:BOOL=OFF \
-          -DSlicer_BUILD_CompareVolumes:BOOL=OFF \
-          -DSlicer_BUILD_DICOM_SUPPORT:BOOL=ON \
-          -DSlicer_BUILD_I18N_SUPPORT:BOOL=OFF \
-          -DSlicer_BUILD_LandmarkRegistration:BOOL=OFF \
-          -DSlicer_BUILD_MULTIMEDIA_SUPPORT:BOOL=OFF \
-          -DSlicer_BUILD_MULTIVOLUME_SUPPORT:BOOL=OFF \
-          -DSlicer_BUILD_QT_DESIGNER_PLUGINS:BOOL=OFF \
-          -DSlicer_BUILD_SurfaceToolbox:BOOL=OFF \
-          -DSlicer_BUILD_WEBENGINE_SUPPORT:BOOL=OFF \
-          -DSlicer_USE_NUMPY:BOOL=OFF \
-          -DSlicer_USE_PYTHONQT:BOOL=ON \
-          -DSlicer_USE_QtTesting:BOOL=OFF \
-          -DSlicer_USE_SCIPY:BOOL=OFF \
-          -DSlicer_USE_SimpleITK:BOOL=OFF \
-          -DSlicer_USE_TBB:BOOL=OFF \
-          -DSlicer_USE_VTK_DEBUG_LEAKS:BOOL=OFF \
-          -S $Slicer_SOURCE_DIR \
-          -B $Slicer_BUILD_DIR
-
-        cmake \
-          --build $Slicer_BUILD_DIR \
-          --config $BUILD_TYPE
-
-        echo "Slicer_DIR=$Slicer_BUILD_DIR/Slicer-build" >> $GITHUB_OUTPUT
-
-    - id: slicertm-build
-      name: Build SlicerTutorialMaker
+    - name: Download Slicer
+      id: slicer-download
       run: |
-        Slicer_DIR=${{ steps.slicer-build.outputs.Slicer_DIR }}
+        download_dir=$(pwd)
 
-        EXTENSION_NAME=SlicerTutorialMaker
-        EXTENSION_SOURCE_DIR=${{ github.workspace }}/$EXTENSION_NAME
-        EXTENSION_BUILD_DIR=${{ github.workspace }}/$EXTENSION_NAME-build
+        package_name=Slicer-5.8.0-linux-amd64
+        filename=${package_name}.tar.gz
+        url=https://download.slicer.org/bitstream/679325961357655fd585ffb5
+        sha512=122ae2611d6d8761f66ef6a316dfff08442df072bf80a23327e374a09935da5e829e60bcf780ffc687b8e208ca696a34a4811218afe89bfcedfc755b823a933d
 
-        cmake \
-          -GNinja \
-          -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE \
-          -DSlicer_DIR:PATH=$Slicer_DIR \
-          -S $EXTENSION_SOURCE_DIR \
-          -B $EXTENSION_BUILD_DIR
+        if [[ ! -f ${download_dir}/${filename} ]]; then
+          echo "[slicer-download] Downloading ${filename}"
+          curl -o ${download_dir}/${filename} -# -SL ${url}
+        else
+          echo "[slicer-download] Skipping download: Found ${filename}"
+        fi
 
-        cmake \
-          --build $EXTENSION_BUILD_DIR \
-          --config $BUILD_TYPE
+        echo "[slicer-download] Checking"
+        echo "${sha512}  ${download_dir}/${filename}" > ${download_dir}/${filename}.sha512
+        sha512sum -c ${download_dir}/${filename}.sha512
+        rm -f ${download_dir}/${filename}.sha512
 
-        echo "EXTENSION_BUILD_DIR=$EXTENSION_BUILD_DIR" >> $GITHUB_OUTPUT
+        echo "[slicer-download] Extracting"
+        tar -xzvf ${download_dir}/${filename}
+
+        install_dir=${download_dir}/${package_name}
+        SLICER_EXECUTABLE=${install_dir}/Slicer
+        echo "[slicer-download] SLICER_EXECUTABLE [${SLICER_EXECUTABLE}]"
+
+        echo "slicer-executable=${SLICER_EXECUTABLE}" >> $GITHUB_OUTPUT
+
+    - name: Check Slicer installation
+      uses: coactions/setup-xvfb@v1.0.1
+      with:
+        run:
+          ${SLICER_EXECUTABLE} --version
+      env:
+        SLICER_EXECUTABLE: ${{ steps.slicer-download.outputs.slicer-executable }}
 
     - name: Test SlicerTutorialMaker
       uses: coactions/setup-xvfb@v1.0.1
       with:
-        run:
-          ctest -V --test-dir ${{ steps.slicertm-build.outputs.EXTENSION_BUILD_DIR }}/build
+        run: |
+          ${SLICER_EXECUTABLE} \
+            --no-splash \
+            --testing \
+            --additional-module-paths ${ADDITIONAL_MODULE_PATH} \
+            --python-code \
+              "import slicer.testing; slicer.testing.runUnitTest(['${ADDITIONAL_MODULE_PATH}'], '${MODULE_NAME}')"
+      env:
+        SLICER_EXECUTABLE: ${{ steps.slicer-download.outputs.slicer-executable }}
+        ADDITIONAL_MODULE_PATH: ${{ github.workspace }}/SlicerTutorialMaker/TutorialMaker
+        MODULE_NAME: TutorialMaker

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.flake8
 !.gitattributes
 !.git-blame-ignore-revs
+!.github/
 !.pre-commit-config.yaml
 !.readthedocs.yaml
 !.puppeteerrc.cjs
@@ -14,9 +15,6 @@
 
 # except for .gitignore
 !.gitignore
-
-# ... and .circleci
-!.circleci
 
 # Exclude Kdevelop4 files ...
 .kdev*


### PR DESCRIPTION
This pull request revisits the approach for running the self-tests.

Instead of attempting to build Slicer, the extension and then execute the tests, it downloads the latest stable Slicer release, and then run the "TutorialMaker" module tests specifying the `--additional-module-paths` parameter along with the `--python-code` argument to directly use `slicer.testing.runUnitTest`.