### PR TITLE
DOC: Add issue templates to streamline the issue creation process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report problems or unexpected behavior
+title: ''
+labels: type:bug
+assignees: ''
+
+---
+
+## Summary
+
+<!-- Give a short summary of what the problem is. Note: Before submitting an error report, please test if the problem is reproducible in the latest Slicer Preview Release and using the lastest version of the extension. If the problem does not occur in the latest Slicer Preview Release/Extension then most likely it has been already fixed and there is no need to report it again. -->
+
+## Steps to reproduce
+
+<!--
+    Generally, developers can only fix those issues that they can reproduce on their computers.
+
+    To achieve this, please:
+    * Describe in this section what you did, what you expected to happen, and what happened instead.
+    * Attach a few screenshots if possible.
+
+    To describe "Actual behavior" and "Expected behavior" you may use the following format:
+    1. Do A
+    2. Do B => Slicer does Y - OK
+    3. Do C => Slicer does Z => ERROR: Slicer should do W instead
+    4. Do D => Slicer does Z - OK
+    5. Do B => Slicer does Y => ERROR: Slicer should do X instead
+-->
+
+## Environment
+- Slicer version: Slicer-5.??.?-YYYY-MM-DD
+- Extension version: YYYY/MM/DD-HH:MM12 (When you open the extension, this date will be logged on the Python Console)
+- Operating system: Windows / Linux / Mac + which version

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement for this project
+title: ''
+labels: type:enhancement
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+<!-- Description of what the problem is. For example, "I'm always frustrated when..." -->
+
+## Describe the solution you'd like
+
+<!-- Description of what you want to happen. -->
+
+## Describe alternatives you've considered
+
+<!-- Description of any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
This commit introduces predefined issue templates to simplify and standardize the process of opening issues. The templates are based on those used in the Slicer repository to ensure consistency and clarity.